### PR TITLE
Use automated integration tests

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,6 @@ pull_request_rules:
     conditions:
       - author~=dependabot\[bot\]|dependabot-preview\[bot\]
       - status-success=Travis CI - Pull Request
-      - label!=terraform
     actions:
       review:
         type: APPROVE

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ stages:
 if: branch = master OR type = pull_request
 
 before_install:
-   - tmpdaemon=$(mktemp)
-   - sudo jq '."registry-mirrors" += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > "$tmpdaemon"
-   - sudo mv "$tmpdaemon" /etc/docker/daemon.json
-   - sudo systemctl daemon-reload
-   - sudo systemctl restart docker
-   - docker system info
+  - tmpdaemon=$(mktemp)
+  - sudo jq '."registry-mirrors" += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > "$tmpdaemon"
+  - sudo mv "$tmpdaemon" /etc/docker/daemon.json
+  - sudo systemctl daemon-reload
+  - sudo systemctl restart docker
+  - docker system info
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ stages:
 
 if: branch = master OR type = pull_request
 
+before_install:
+   - tmpdaemon=$(mktemp)
+   - sudo jq '."registry-mirrors" += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > "$tmpdaemon"
+   - sudo mv "$tmpdaemon" /etc/docker/daemon.json
+   - sudo systemctl daemon-reload
+   - sudo systemctl restart docker
+   - docker system info
+
 jobs:
   include:
     - stage: lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: minimal
 
 stages:
   - lint
+  - test
   - deploy
 
 if: branch = master OR type = pull_request
@@ -13,6 +14,14 @@ jobs:
     - stage: lint
       name: Project Syntax Verification
       script: make docker/run target=lint
+    - stage: test
+      name: Apply Terraform test configs in mockstack
+      install:
+        - make docker-compose/install
+        - make mockstack/up
+      script: make mockstack/pytest
+      after_script:
+        - make mockstack/clean
     - stage: deploy
       if: branch = master AND type = push AND repo = plus3it/terraform-aws-tardigrade-route53-zone
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,32 +4,15 @@ language: minimal
 
 stages:
   - lint
-  - test
   - deploy
 
 if: branch = master OR type = pull_request
-
-before_install:
-  - tmpdaemon=$(mktemp)
-  - sudo jq '."registry-mirrors" += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > "$tmpdaemon"
-  - sudo mv "$tmpdaemon" /etc/docker/daemon.json
-  - sudo systemctl daemon-reload
-  - sudo systemctl restart docker
-  - docker system info
 
 jobs:
   include:
     - stage: lint
       name: Project Syntax Verification
       script: make docker/run target=lint
-    - stage: test
-      name: Apply Terraform test configs in mockstack
-      install:
-        - make docker-compose/install
-        - make mockstack/up
-      script: make mockstack/pytest
-      after_script:
-        - make mockstack/clean
     - stage: deploy
       if: branch = master AND type = push AND repo = plus3it/terraform-aws-tardigrade-route53-zone
       before_script:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
 PROVIDER_ALIAS := ns
+ONLY_MOTO := true
 
 include $(shell test -f .tardigrade-ci || curl -sSL -o .tardigrade-ci "https://raw.githubusercontent.com/plus3it/tardigrade-ci/master/bootstrap/Makefile.bootstrap"; echo .tardigrade-ci)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ make terraform/pytest PYTEST_ARGS="-v --nomock"
 For automated testing, PYTEST_ARGS is optional and no profile is needed:
 
 ```
+make mockstack/up
 make terraform/pytest PYTEST_ARGS="-v"
+make mockstack/clean
 ```
 
 <!-- BEGIN TFDOCS -->

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ delegation records. You must pass both the `aws` and `aws.ns` providers even
 if you are not using the subzone delegation option, in which case you can
 simply pass the same provider to both `aws` and `aws.ns`.
 
+## Testing
+
+At the moment, testing is manual:
+
+```
+# Replace "xxx" with an actual AWS profile, then execute the integration tests.
+export AWS_PROFILE=xxx 
+make terraform/pytest PYTEST_ARGS="-v --nomock"
+```
+
 <!-- BEGIN TFDOCS -->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,18 @@ simply pass the same provider to both `aws` and `aws.ns`.
 
 ## Testing
 
-At the moment, testing is manual:
+Manual testing:
 
 ```
 # Replace "xxx" with an actual AWS profile, then execute the integration tests.
 export AWS_PROFILE=xxx 
 make terraform/pytest PYTEST_ARGS="-v --nomock"
+```
+
+For automated testing, PYTEST_ARGS is optional and no profile is needed:
+
+```
+make terraform/pytest PYTEST_ARGS="-v"
 ```
 
 <!-- BEGIN TFDOCS -->

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For automated testing, PYTEST_ARGS is optional and no profile is needed:
 
 ```
 make mockstack/up
-make terraform/pytest PYTEST_ARGS="-v"
+make terraform/pytest PYTEST_ARGS="-v --only-moto"
 make mockstack/clean
 ```
 


### PR DESCRIPTION
Uses tardigrade-ci's ability to run automated integration tests against a mock AWS stack.