### PR TITLE
Correct README instructions for running the automated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For automated testing, PYTEST_ARGS is optional and no profile is needed:
 
 ```
 make mockstack/up
-make terraform/pytest PYTEST_ARGS="-v --only-moto"
+make terraform/pytest PYTEST_ARGS="-v"
 make mockstack/clean
 ```
 


### PR DESCRIPTION
The Makefile already sets ONLY_MOTO, so it's not necessary to also specify "--only-moto" from the command line.